### PR TITLE
Installation with pixi environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ external/sundials/
 external/gmsh/
 external/h2lib/
 main/tetmagVersion.h
+# pixi environments
+.pixi/*
+

--- a/doc/usage/installation-pixi.rst
+++ b/doc/usage/installation-pixi.rst
@@ -1,0 +1,93 @@
+Installation using pixi
+======================
+
+This section describes how to build and run tetmag using `pixi`_.
+This is an optional method that provides a self-contained and reproducible
+environment without relying on system-wide installations of compilers and
+libraries.
+
+What is pixi?
+-------------
+
+`pixi`_ is a cross-platform package manager and workflow tool based on the
+conda-forge ecosystem. It allows users to define project-specific environments
+that include compilers, build tools, and libraries. These environments are
+isolated from the system and help avoid dependency conflicts.
+
+Install pixi
+------------
+
+pixi can be installed using the official installer:
+
+.. code-block:: bash
+
+   curl -fsSL https://pixi.sh/install.sh | bash
+
+After installation, ensure that pixi is available:
+
+.. code-block:: bash
+
+   pixi --version
+
+If necessary, restart your shell or ensure that ``~/.pixi/bin`` is in your
+``PATH``.
+
+Set up the environment
+----------------------
+
+Clone the tetmag repository and install the required dependencies:
+
+.. code-block:: bash
+
+   git clone https://github.com/R-Hertel/tetmag.git
+   cd tetmag
+   pixi install
+
+This will create a local environment in the ``.pixi/`` directory containing all
+required tools and libraries.
+
+Compile tetmag
+--------------
+
+Configure and build the project using pixi:
+
+.. code-block:: bash
+
+   pixi run configure  # runs "cmake -S . -B build"
+   pixi run build  # runs "cmake --build build -j"
+
+The executable will be created in the ``build/`` directory.
+
+Run tetmag
+----------
+
+You can run tetmag either through pixi:
+
+.. code-block:: bash
+
+   pixi run build/tetmag <input-file>
+
+or directly:
+
+.. code-block:: bash
+
+   ./build/tetmag <input-file>
+
+Notes
+-----
+
+- Pixi provides its own compiler toolchain and libraries, so no system-wide
+  installation of dependencies is required.
+- This makes the installation more portable across different Linux distributions.
+- Changing compiler versions or versions of dependencies may be easier
+  than for a given Linux distribution.
+- It is recommended to use ``pixi run`` for configuration and build steps to
+  ensure the pixi environment is active.
+- If you encounter build issues, a clean rebuild can help:
+
+  .. code-block:: bash
+
+     rm -rf build
+     pixi install
+
+.. _pixi: https://pixi.sh

--- a/doc/usage/installation.rst
+++ b/doc/usage/installation.rst
@@ -141,3 +141,7 @@ Instead of using compiler flags, a convenient way to set various parameters and 
 .. image:: ./../figs/install/ccmake_terminal.png
 
 
+Installation of environment with pixi
+-------------------------------------
+
+See `installation with pixi <installation-pixi.html>`__.

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,0 +1,24 @@
+[workspace]
+authors = ["Hans Fangohr <hans.fangohr@mpsd.mpg.de>"]
+channels = ["conda-forge"]
+name = "tetmag"
+platforms = ["linux-64"]
+version = "0.1.0"
+
+[tasks]
+# convenience tasks
+clean = "rm -rf build"
+configure = "cmake -S . -B build"
+build = "cmake --build build -j"
+
+[dependencies]
+cmake = ">=4.3.1,<5"
+eigen = ">=5.0.1,<6"
+vtk = ">=9.3.1,<10"
+pkg-config = ">=0.29.2,<0.30"
+gcc = "==14.3"
+gxx = ">=14.3.0,<14.4"
+boost-cpp = ">=1.85.0,<2"
+make = ">=4.4.1,<5"
+git = ">=2.53.0,<3"
+binutils = ">=2.45.1,<3"

--- a/pixi.toml
+++ b/pixi.toml
@@ -12,7 +12,7 @@ build = "cmake --build build -j"
 
 [dependencies]
 cmake = ">=4.3.1,<5"
-eigen = ">=5.0.1,<6"
+eigen = ">=3.4.0,<6"
 vtk = ">=9.3.1,<10"
 pkg-config = ">=0.29.2,<0.30"
 gcc = "==14.3"

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,7 +1,6 @@
 [workspace]
-authors = ["Hans Fangohr <hans.fangohr@mpsd.mpg.de>"]
 channels = ["conda-forge"]
-name = "tetmag"
+name = "tetmag-env"
 platforms = ["linux-64"]
 version = "0.1.0"
 


### PR DESCRIPTION
Additional option to install dependencies and compilers and compile tetmag using pixi (https://pixi.sh)

Main file for functionality: `pixi.toml` (CUDA support missing).

If this should be advertised to users, then the description in `docs/usage/installation-pixi.rst` could be a starting point.

